### PR TITLE
Export database driver

### DIFF
--- a/database/db_functions.go
+++ b/database/db_functions.go
@@ -21,7 +21,7 @@ func (dbs *SDAdb) RegisterFile(uploadPath, uploadUser string) (string, error) {
 
 	var fileId string
 
-	err := dbs.db.QueryRow(query, uploadPath, uploadUser).Scan(&fileId)
+	err := dbs.DB.QueryRow(query, uploadPath, uploadUser).Scan(&fileId)
 	return fileId, err
 }
 
@@ -38,6 +38,6 @@ func (dbs *SDAdb) MarkFileAsUploaded(fileId, userId, message string) error {
 
 	query := "INSERT INTO sda.file_event_log(file_id, event, user_id, message) VALUES ($1, 'uploaded', $2, $3)"
 
-	_, err := dbs.db.Exec(query, fileId, userId, message)
+	_, err := dbs.DB.Exec(query, fileId, userId, message)
 	return err
 }

--- a/database/db_functions_test.go
+++ b/database/db_functions_test.go
@@ -28,12 +28,12 @@ func (suite *DatabaseTests) TestRegisterFile() {
 
 	// check that the file is in the database
 	exists := false
-	err = db.db.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.files WHERE id=$1)", fileId).Scan(&exists)
+	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.files WHERE id=$1)", fileId).Scan(&exists)
 	assert.Nil(suite.T(), err, "Failed to check if registered file exists")
 	assert.True(suite.T(), exists, "RegisterFile() did not insert a row into sda.files with id: "+fileId)
 
 	// check that there is a "registered" file event connected to the file
-	err = db.db.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.file_event_log WHERE file_id=$1 AND event='registered')", fileId).Scan(&exists)
+	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.file_event_log WHERE file_id=$1 AND event='registered')", fileId).Scan(&exists)
 	assert.Nil(suite.T(), err, "Failed to check if registered file event exists")
 	assert.True(suite.T(), exists, "RegisterFile() did not insert a row into sda.file_event_log with id: "+fileId)
 
@@ -64,7 +64,7 @@ func (suite *DatabaseTests) TestMarkFileAsUploaded() {
 
 	exists := false
 	// check that there is an "uploaded" file event connected to the file
-	err = db.db.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.file_event_log WHERE file_id=$1 AND event='uploaded')", fileId).Scan(&exists)
+	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.file_event_log WHERE file_id=$1 AND event='uploaded')", fileId).Scan(&exists)
 	assert.Nil(suite.T(), err, "Failed to check if uploaded file event exists")
 	assert.True(suite.T(), exists, "MarkFileAsUploaded() did not insert a row into sda.file_event_log with id: "+fileId)
 }

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -76,7 +76,7 @@ func (suite *DatabaseTests) TestNewSDAdb() {
 func (suite *DatabaseTests) TestConnect() {
 
 	// test connecting to a database
-	db := SDAdb{db: nil, Version: -1, Config: suite.dbConf}
+	db := SDAdb{DB: nil, Version: -1, Config: suite.dbConf}
 
 	err := db.Connect()
 	assert.Nil(suite.T(), err, "failed connecting: %s", err)
@@ -90,7 +90,7 @@ func (suite *DatabaseTests) TestConnect() {
 	db.Close()
 	query := "SELECT MAX(version) FROM local_ega.dbschema_version"
 	var dbVersion = -1
-	err = db.db.QueryRow(query).Scan(&dbVersion)
+	err = db.DB.QueryRow(query).Scan(&dbVersion)
 	assert.NotNil(suite.T(), err, "query possible on closed connection")
 
 	// test reconnection by using getVersion()
@@ -130,7 +130,7 @@ func (suite *DatabaseTests) TestClose() {
 	// check that we can't do queries on a closed connection
 	query := "SELECT MAX(version) FROM local_ega.dbschema_version"
 	var dbVersion = -1
-	err = db.db.QueryRow(query).Scan(&dbVersion)
+	err = db.DB.QueryRow(query).Scan(&dbVersion)
 	assert.NotNil(suite.T(), err, "query possible on closed connection")
 
 	// check that nothing happens if Close is called on a closed connection


### PR DESCRIPTION
This PR exports the database driver so that it can be used to develop in other repositories. Without this change, every new query had to be added to the common repository in order to be exported and used in any other project.